### PR TITLE
v5.13: Recycle Bin folders informational in remnant scan (#9)

### DIFF
--- a/autodesk_complete_uninstaller.bat
+++ b/autodesk_complete_uninstaller.bat
@@ -1,5 +1,6 @@
 @echo off
 setlocal enabledelayedexpansion
+set "SELFDIR=%~dp0"
 chcp 437 >nul 2>&1
 title Autodesk Universal Uninstaller v5.12
 
@@ -3007,13 +3008,20 @@ if !RS_DTCWS! gtr 0 (
 REM === 6. FULL C: DRIVE SEARCH ===
 <nul set /p "=  !DIM![!time:~0,8!]!R! !CWHT![ 6/15]!R! Full C: drive search........... "
 set RS_CDRIVE=0
+set RS_RECYCLE=0
 echo --- AUTODESK FOLDERS ANYWHERE ON C: --- >> "!SCANFILE!"
 echo  Searching C: drive for Autodesk folders... >> "!SCANFILE!"
-dir /s /b /ad "C:\*Autodesk*" 2>nul | findstr /v /i /c:"Desktop\Autodesk_Uninstaller" /c:"\Downloads\Autodesk" /c:"\Downloads\AutoCAD" /c:"\Downloads\Revit" /c:"\Downloads\Maya" /c:"\Downloads\3ds" /c:"\Downloads\Inventor" /c:"\Downloads\Civil" /c:"\Downloads\Navisworks" /c:"\Downloads\DWG" > "!LOGDIR!\remnant_cdrive_tmp.txt"
+dir /s /b /ad "C:\*Autodesk*" 2>nul | findstr /v /i /c:"Desktop\Autodesk_Uninstaller" /c:"\Downloads\Autodesk" /c:"\Downloads\AutoCAD" /c:"\Downloads\Revit" /c:"\Downloads\Maya" /c:"\Downloads\3ds" /c:"\Downloads\Inventor" /c:"\Downloads\Civil" /c:"\Downloads\Navisworks" /c:"\Downloads\DWG" /c:"%SELFDIR%" > "!LOGDIR!\remnant_cdrive_tmp.txt"
 for /f "tokens=*" %%L in ('type "!LOGDIR!\remnant_cdrive_tmp.txt" 2^>nul') do (
-    set /a RS_CDRIVE+=1
-    <nul set /p "=!ESC![50G!DIM!scanning: !RS_CDRIVE!  !R!"
-    echo  %%L >> "!SCANFILE!"
+    echo "%%L" | findstr /i /c:"$Recycle.Bin" >nul 2>&1
+    if !errorlevel! equ 0 (
+        set /a RS_RECYCLE+=1
+        echo  RECYCLE-BIN ^(informational - already deleted, pending purge^): %%L >> "!SCANFILE!"
+    ) else (
+        set /a RS_CDRIVE+=1
+        <nul set /p "=!ESC![50G!DIM!scanning: !RS_CDRIVE!  !R!"
+        echo  %%L >> "!SCANFILE!"
+    )
 )
 del "!LOGDIR!\remnant_cdrive_tmp.txt" 2>nul
 echo. >> "!SCANFILE!"
@@ -3371,6 +3379,10 @@ echo.
 if !RS_GENERIC! gtr 0 (
     echo.
     echo   !DIM!+ !RS_GENERIC! GENERIC-ICON entries ^(informational only, not counted^)!R!
+)
+if !RS_RECYCLE! gtr 0 (
+    echo   !DIM!+ !RS_RECYCLE! Recycle Bin folders ^(informational only, not counted or deleted^)!R!
+    echo [!time:~0,8!] Scan: !RS_RECYCLE! Recycle Bin folders ^(informational^) >> "!CLOG!"
 )
 echo.
 echo [!time:~0,8!] Remnant scan total: !RS_TOTAL! >> "!CLOG!"

--- a/autodesk_complete_uninstaller.bat
+++ b/autodesk_complete_uninstaller.bat
@@ -1,6 +1,7 @@
 @echo off
 setlocal enabledelayedexpansion
 set "SELFDIR=%~dp0"
+set "SELFDIR=%SELFDIR:~0,-1%"
 chcp 437 >nul 2>&1
 title Autodesk Universal Uninstaller v5.12
 


### PR DESCRIPTION
Closes #9. Recycle Bin matches in option 7's C: drive search are now reported as informational (not counted, not deleted), mirroring GENERIC-ICON handling. Also drops the tool's own directory from the search. CRLF preserved; RS_RECYCLE excluded from RS_TOTAL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup scan accuracy by avoiding false matches in the tool’s own folder during full-drive searches.
  * Separated recycle-bin-related Autodesk remnants from standard C: drive counts so the summary is clearer and more accurate.
  * Updated the scan summary to show recycle-bin findings when present without inflating the main total.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->